### PR TITLE
Create .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+web/node_modules


### PR DESCRIPTION
在本地化 build 镜像时，排除node_modules目录，以兼容在Linux Mac 和 Windows 打包前端