### PR TITLE
fix (tortoise.exceptions.OperationalError: invalid input for query ar…

### DIFF
--- a/app/api/v1/auditlog/auditlog.py
+++ b/app/api/v1/auditlog/auditlog.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from fastapi import APIRouter, Query
 from tortoise.expressions import Q
 
@@ -17,8 +18,8 @@ async def get_audit_log_list(
     method: str = Query("", description="请求方法"),
     summary: str = Query("", description="接口描述"),
     status: int = Query(None, description="状态码"),
-    start_time: str = Query("", description="开始时间"),
-    end_time: str = Query("", description="结束时间"),
+    start_time: datetime = Query("", description="开始时间"),
+    end_time: datetime = Query("", description="结束时间"),
 ):
     q = Q()
     if username:


### PR DESCRIPTION
File "D:\anning\vue-fastapi-admin\app\api\v1\auditlog\auditlog.py", line 41, in get_audit_log_list
    audit_log_objs = await AuditLog.filter(q).offset((page - 1) * page_size).limit(page_size).order_by("-created_at")
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\anning\vue-fastapi-admin\.venv\Lib\site-packages\tortoise\queryset.py", line 1141, in _execute
    instance_list = await self._db.executor_class(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\anning\vue-fastapi-admin\.venv\Lib\site-packages\tortoise\backends\base\executor.py", line 132, in execute_select
    _, raw_results = await self.db.execute_query(sql, values)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\anning\vue-fastapi-admin\.venv\Lib\site-packages\tortoise\backends\base_postgres\client.py", line 41, in _translate_exceptions
    return await self._translate_exceptions(func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\anning\vue-fastapi-admin\.venv\Lib\site-packages\tortoise\backends\asyncpg\client.py", line 89, in _translate_exceptions
    raise OperationalError(exc)
tortoise.exceptions.OperationalError: invalid input for query argument $1: '2025-05-14 00:00:00' (expected a datetime.date or datetime.datetime instance, got 'str')

类型不匹配错误，发生在使用 Tortoise-ORM 查询数据库时。

在构建查询条件 q 时，直接传入了字符串类型的日期（如 '2025-05-14 00:00:00'），但 Tortoise-ORM 要求日期类型参数必须是 datetime.date 或 datetime.datetime 实例，而不是字符串。

解决方案： 使用 Pydantic 模型中自动转换
