### PR TITLE
排除日志中的文件对象

### DIFF
--- a/app/core/middlewares.py
+++ b/app/core/middlewares.py
@@ -68,7 +68,14 @@ class HttpAuditLogMiddleware(BaseHTTPMiddleware):
             except json.JSONDecodeError:
                 try:
                     body = await request.form()
-                    args.update(body)
+                    # args.update(body)
+                    for k, v in body.items():
+                        if hasattr(v, "filename"):  # 文件上传行为
+                            args[k] = v.filename
+                        elif isinstance(v, list) and v and hasattr(v[0], "filename"):
+                            args[k] = [file.filename for file in v]
+                        else:
+                            args[k] = v
                 except Exception:
                     pass
 


### PR DESCRIPTION
当发生文件上传行为时，Tortoise ORM 的 JSONField 不能序列化`UploadFile`，`get_request_args`会把请求体内容（包括上传的文件对象）直接放进日志，导致报错。故此处需要过滤文件体，只保留文件名或其它可序列化信息。